### PR TITLE
add port argument for run and run_ssl

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -324,9 +324,7 @@ impl InteractionHandler {
 
     /// This is a predefined function that starts an `actix_web::HttpServer` and binds `self.interaction` to `/api/discord/interactions`.
     /// Note that you'll eventually have to switch to an HTTPS server. This function does not provide this.
-    ///
-    /// **The server runs on port 10080!**
-    pub async fn run(self) -> std::io::Result<()> {
+    pub async fn run(self, port: u16) -> std::io::Result<()> {
         HttpServer::new(move || {
             App::new().data(self.clone()).route(
                 "/api/discord/interactions",
@@ -337,15 +335,13 @@ impl InteractionHandler {
                 ),
             )
         })
-        .bind("0.0.0.0:10080")?
+        .bind(("0.0.0.0:{}", port))?
         .run()
         .await
     }
 
     /// Same as [`InteractionHandler::run`] but starts a server with SSL/TLS.
-    ///
-    /// **The server runs on port 10443!**
-    pub async fn run_ssl(self, server_conf: ServerConfig) -> std::io::Result<()> {
+    pub async fn run_ssl(self, server_conf: ServerConfig, port: u16) -> std::io::Result<()> {
         HttpServer::new(move || {
             App::new().data(self.clone()).route(
                 "/api/discord/interactions",
@@ -356,7 +352,7 @@ impl InteractionHandler {
                 ),
             )
         })
-        .bind_rustls("0.0.0.0:10443", server_conf)?
+        .bind_rustls(format!("0.0.0.0:{}", port), server_conf)?
         .run()
         .await
     }


### PR DESCRIPTION
This is to be able to customize your port, instead being forced to use `10080` and `10443` as ports for the API.

