### PR TITLE
Add support for dynamic guild command management

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ More than welcome! :D
 - [x] - Bind interactions to a function (with the help of a macro)
 - [x] - Properly respond to interactions from Discord
 - [x] - Nice system to make follow-up messages.
-- [ ] - Nice system to manage guild-specific commands.
+- [x] - Nice system to manage guild-specific commands.
 - [x] - Support for components (buttons, dropdowns, etc)
 - [ ] - Not a pile of spaghetti code that just works (oops...👀)
 

--- a/attributes/src/lib.rs
+++ b/attributes/src/lib.rs
@@ -8,8 +8,6 @@ use syn::{Expr, ExprReturn, FnArg, ReturnType, Stmt};
 
 
 
-
-
 fn handler(_attr:TokenStream, item: TokenStream, defer_return: quote::__private::TokenStream) -> TokenStream{
 
     // There is _probably_ a more efficient way to do what I want to do, but hey I am here
@@ -56,11 +54,63 @@ fn handler(_attr:TokenStream, item: TokenStream, defer_return: quote::__private:
         }
     }
 
+    // Find the name of the Context parameter
+    let mut ctxname: Option<syn::Ident> = None;
+    let mut handlename: Option<syn::Ident> = None;
+    eprintln!("{:#?}", params);
+
+    // I am honestly laughing at this...
+    // But hey it works! :D
+    for p in params {
+        if let FnArg::Typed(t) = p {
+            match &*t.ty{
+                // This might be a Context
+                syn::Type::Path(b) => {
+                    for segment in b.path.segments.clone(){
+                        if segment.ident == "Context"{
+                            if let syn::Pat::Ident(a) = &*t.pat {
+                                ctxname = Some(a.ident.clone());
+                                break;
+                            }
+                        }
+                    }
+                },
+                // This might be an &InteractionHandler!
+                syn::Type::Reference(r) => {
+                    let e = r.elem.clone();
+                    if let syn::Type::Path(w) = &*e{
+                        for segment in w.path.segments.clone(){
+                            if segment.ident == "InteractionHandler"{
+                                if let syn::Pat::Ident(a) = &*t.pat {
+                                    handlename = Some(a.ident.clone());
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    
+                },
+                _ => {continue;}
+            }
+        }
+    }
+
+    if ctxname.is_none(){
+        panic!("Couldn't determine the Context parameter. Make sure you take a `Context` as an argument");
+    }
+
+    let mut ih_n = quote!(_);
+    
+    if handlename.is_some(){
+        ih_n = quote!(#handlename);
+    }
+
+
     // Using quasi-quoting to generate a new function. This is what will be the end function returned to the compiler.
     if !defer {
         // Build the function
         let subst_fn = quote! {
-            #vis fn #fname<'context> (#params) -> ::std::pin::Pin<::std::boxed::Box<dyn 'context + Send + ::std::future::Future<Output = #ret>>>{
+            #vis fn #fname<'context> (#ih_n: &InteractionHandler, #ctxname: Context) -> ::std::pin::Pin<::std::boxed::Box<dyn 'context + Send + ::std::future::Future<Output = #ret>>>{
                 Box::pin(async move {
                     #body
                 })
@@ -95,16 +145,9 @@ fn handler(_attr:TokenStream, item: TokenStream, defer_return: quote::__private:
             );
         }));
 
-        // Find the name of the Context parameter
-        let mut ctxname: Option<syn::Ident> = None;
-        for p in params {
-            if let FnArg::Typed(t) = p {
-                if let syn::Pat::Ident(a) = &*t.pat {
-                    ctxname = Some(a.ident.clone());
-                    break;
-                }
-            }
-        }
+        
+
+        
 
         // Unwrap, unwrap, unwrap, unwrap.
         let expra = expr
@@ -118,7 +161,7 @@ fn handler(_attr:TokenStream, item: TokenStream, defer_return: quote::__private:
         // The difference here being that the non-deffered function doesn't have to spawn a new thread that
         // does the actual work. Here we need it to reply with a deffered channel message.
         let subst_fn = quote! {
-            #vis fn #fname<'context> (#params) -> ::std::pin::Pin<::std::boxed::Box<dyn 'context + Send + ::std::future::Future<Output = #ret>>>{
+            #vis fn #fname<'context> (#ih_n: &InteractionHandler, #ctxname: Context) -> ::std::pin::Pin<::std::boxed::Box<dyn 'context + Send + ::std::future::Future<Output = #ret>>>{
                 Box::pin(async move {
                     ::rusty_interaction::actix::Arbiter::spawn(async move {
                         #(#nvec)*
@@ -210,11 +253,59 @@ pub fn slash_command_test(_attr: TokenStream, item: TokenStream) -> TokenStream 
         }
     }
 
+    let mut ctxname: Option<syn::Ident> = None;
+    let mut handlename: Option<syn::Ident> = None;
+    // I am honestly laughing at this...
+    // But hey it works! :D
+    for p in params {
+        if let FnArg::Typed(t) = p {
+            match &*t.ty{
+                // This might be a Context
+                syn::Type::Path(b) => {
+                    for segment in b.path.segments.clone(){
+                        if segment.ident == "Context"{
+                            if let syn::Pat::Ident(a) = &*t.pat {
+                                ctxname = Some(a.ident.clone());
+                                break;
+                            }
+                        }
+                    }
+                },
+                // This might be an &InteractionHandler!
+                syn::Type::Reference(r) => {
+                    let e = r.elem.clone();
+                    if let syn::Type::Path(w) = &*e{
+                        for segment in w.path.segments.clone(){
+                            if segment.ident == "InteractionHandler"{
+                                if let syn::Pat::Ident(a) = &*t.pat {
+                                    handlename = Some(a.ident.clone());
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    
+                },
+                _ => {continue;}
+            }
+        }
+    }
+
+    if ctxname.is_none(){
+        panic!("Couldn't determine the Context parameter. Make sure you take a `Context` as an argument");
+    }
+
+    let mut ih_n = quote!(_);
+    
+    if handlename.is_some(){
+        ih_n = quote!(#handlename);
+    }
+
     // Using quasi-quoting to generate a new function. This is what will be the end function returned to the compiler.
     if !defer {
         // Build the function
         let subst_fn = quote! {
-            #vis fn #fname<'context> (#params) -> ::std::pin::Pin<::std::boxed::Box<dyn 'context + Send + ::std::future::Future<Output = #ret>>>{
+            #vis fn #fname<'context> (#ih_n: &InteractionHandler, #ctxname: Context) -> ::std::pin::Pin<::std::boxed::Box<dyn 'context + Send + ::std::future::Future<Output = #ret>>>{
                 Box::pin(async move {
                     #body
                 })
@@ -249,17 +340,6 @@ pub fn slash_command_test(_attr: TokenStream, item: TokenStream) -> TokenStream 
             );
         }));
 
-        // Find the name of the Context parameter
-        let mut ctxname: Option<syn::Ident> = None;
-        for p in params {
-            if let FnArg::Typed(t) = p {
-                if let syn::Pat::Ident(a) = &*t.pat {
-                    ctxname = Some(a.ident.clone());
-                    break;
-                }
-            }
-        }
-
         // Unwrap, unwrap, unwrap, unwrap.
         let expra = expr
             .unwrap_or_else(|| panic!("Expected return"))
@@ -272,7 +352,7 @@ pub fn slash_command_test(_attr: TokenStream, item: TokenStream) -> TokenStream 
         // The difference here being that the non-deffered function doesn't have to spawn a new thread that
         // does the actual work. Here we need it to reply with a deffered channel message.
         let subst_fn = quote! {
-            #vis fn #fname<'context> (#params) -> ::std::pin::Pin<::std::boxed::Box<dyn 'context + Send + ::std::future::Future<Output = #ret>>>{
+            #vis fn #fname<'context> (#ih_n: &InteractionHandler, #ctxname: Context) -> ::std::pin::Pin<::std::boxed::Box<dyn 'context + Send + ::std::future::Future<Output = #ret>>>{
                 Box::pin(async move {
                     ::actix::Arbiter::spawn(async move {
                         #(#nvec)*

--- a/attributes/src/lib.rs
+++ b/attributes/src/lib.rs
@@ -57,7 +57,7 @@ fn handler(_attr:TokenStream, item: TokenStream, defer_return: quote::__private:
     // Find the name of the Context parameter
     let mut ctxname: Option<syn::Ident> = None;
     let mut handlename: Option<syn::Ident> = None;
-    eprintln!("{:#?}", params);
+    // eprintln!("{:#?}", params);
 
     // I am honestly laughing at this...
     // But hey it works! :D

--- a/attributes/src/lib.rs
+++ b/attributes/src/lib.rs
@@ -110,7 +110,7 @@ fn handler(_attr:TokenStream, item: TokenStream, defer_return: quote::__private:
     if !defer {
         // Build the function
         let subst_fn = quote! {
-            #vis fn #fname<'context> (#ih_n: &InteractionHandler, #ctxname: Context) -> ::std::pin::Pin<::std::boxed::Box<dyn 'context + Send + ::std::future::Future<Output = #ret>>>{
+            #vis fn #fname (#ih_n: &mut InteractionHandler, #ctxname: Context) -> ::std::pin::Pin<::std::boxed::Box<dyn Send + ::std::future::Future<Output = #ret> + '_>>{
                 Box::pin(async move {
                     #body
                 })
@@ -161,7 +161,7 @@ fn handler(_attr:TokenStream, item: TokenStream, defer_return: quote::__private:
         // The difference here being that the non-deffered function doesn't have to spawn a new thread that
         // does the actual work. Here we need it to reply with a deffered channel message.
         let subst_fn = quote! {
-            #vis fn #fname<'context> (#ih_n: &InteractionHandler, #ctxname: Context) -> ::std::pin::Pin<::std::boxed::Box<dyn 'context + Send + ::std::future::Future<Output = #ret>>>{
+            #vis fn #fname (#ih_n: &mut InteractionHandler, #ctxname: Context) -> ::std::pin::Pin<::std::boxed::Box<dyn Send + ::std::future::Future<Output = #ret> + '_>>{
                 Box::pin(async move {
                     ::rusty_interaction::actix::Arbiter::spawn(async move {
                         #(#nvec)*

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,16 +1,16 @@
-use crate::{expect_successful_api_response_and_return, expect_specific_api_response};
 use crate::security::*;
-use crate::types::HttpError;
-use crate::types::interaction::*;
-use crate::types::Snowflake;
 use crate::types::application::*;
+use crate::types::interaction::*;
+use crate::types::HttpError;
+use crate::types::Snowflake;
+use crate::{expect_specific_api_response, expect_successful_api_response_and_return};
 use actix_web::http::StatusCode;
 use actix_web::{web, App, HttpRequest, HttpResponse, HttpServer, Result};
 use reqwest::header;
 use reqwest::Client;
 
-use std::fmt;
 use log::{debug, error};
+use std::fmt;
 
 use ed25519_dalek::PublicKey;
 
@@ -21,8 +21,10 @@ use std::{collections::HashMap, future::Future, pin::Pin, sync::Mutex};
 /// Alias for InteractionResponse
 pub type HandlerResponse = InteractionResponse;
 
-type HandlerFunction = fn(&mut InteractionHandler, Context) -> Pin<Box<dyn Future<Output = HandlerResponse> + Send + '_>>;
-
+type HandlerFunction = fn(
+    &mut InteractionHandler,
+    Context,
+) -> Pin<Box<dyn Future<Output = HandlerResponse> + Send + '_>>;
 
 macro_rules! match_handler_response {
     ($value_name:expr, $response:ident) => {
@@ -48,7 +50,6 @@ macro_rules! match_handler_response {
     };
 }
 
-
 #[derive(Clone)]
 /// The InteractionHandler is the 'thing' that will handle your incoming interactions.
 /// It does interaction validation (as required by Discord) and provides a pre-defined actix-web server
@@ -61,13 +62,14 @@ pub struct InteractionHandler {
 
     global_handles: HashMap<&'static str, HandlerFunction>,
     component_handles: HashMap<&'static str, HandlerFunction>,
-    guild_handles: HashMap<Snowflake, HandlerFunction>
+    guild_handles: HashMap<Snowflake, HandlerFunction>,
 }
 
-// Only here to make Debug less generic, so I can send a reference 
-impl fmt::Debug for InteractionHandler{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result{
-        return f.debug_struct("InteractionHandler")
+// Only here to make Debug less generic, so I can send a reference
+impl fmt::Debug for InteractionHandler {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        return f
+            .debug_struct("InteractionHandler")
             .field("app_public_key", &self.app_public_key)
             .field("global_handles_len", &self.global_handles.len())
             .field("component_handles_len", &self.component_handles.len())
@@ -77,14 +79,18 @@ impl fmt::Debug for InteractionHandler{
 
 impl InteractionHandler {
     /// Initalizes a new `InteractionHandler`
-    pub fn new(app_id: Snowflake, pbk_str: &str, token: Option<&'static str>) -> InteractionHandler {
+    pub fn new(
+        app_id: Snowflake,
+        pbk_str: &str,
+        token: Option<&'static str>,
+    ) -> InteractionHandler {
         let pbk_bytes =
             hex::decode(pbk_str).expect("Failed to parse the public key from hexadecimal");
 
         let app_public_key =
             PublicKey::from_bytes(&pbk_bytes).expect("Failed to parse public key.");
 
-        if let Some(token) = token{  
+        if let Some(token) = token {
             let mut headers = header::HeaderMap::new();
             let mut auth_value = header::HeaderValue::from_static(token);
             auth_value.set_sensitive(true);
@@ -99,8 +105,7 @@ impl InteractionHandler {
                 component_handles: HashMap::new(),
                 guild_handles: HashMap::new(),
             }
-        }
-        else{
+        } else {
             InteractionHandler {
                 application_id: app_id,
                 app_public_key: app_public_key,
@@ -110,8 +115,6 @@ impl InteractionHandler {
                 guild_handles: HashMap::new(),
             }
         }
-
-        
     }
 
     /// Binds an async function to a **global** command.
@@ -127,10 +130,10 @@ impl InteractionHandler {
     ///     return todo!("Do work and return a response");
     /// }
     /// ```
-    /// 
+    ///
     /// # Note
     /// The handler will first check if a guild-specific handler is available. If not, it will try to match a global command. If that fails too, an error will be returned.
-    /// 
+    ///
     /// # Example
     /// ```ignore
     /// # use rusty_interaction::types::interaction::{Context, InteractionResponse};
@@ -161,18 +164,18 @@ impl InteractionHandler {
     /// Binds an async function to a **component**.
     /// Your function must take a [`Context`] as an argument and must return a [`InteractionResponse`].
     /// Use the `#[component_handler]` procedural macro for your own convinence.eprintln!
-    /// 
+    ///
     /// # Example
     /// ```ignore
     /// use rusty_interaction::handler::InteractionHandler;
     /// use rusty_interaction::types::components::*;
     /// use rusty_interaction::types::interaction::*;
-    /// 
+    ///
     /// #[component_handler]
     /// async fn comp_hand(ctx: Context) -> InteractionResponse {
     ///     return ctx.respond().content("Some message content").finish();
     /// }
-    /// 
+    ///
     /// #[slash_command]
     /// async fn spawn_buttons(ctx: Context) -> InteractionResponse {
     ///     // Let's build our message!
@@ -202,7 +205,7 @@ impl InteractionHandler {
     ///     .finish();
 
     ///     return resp;
-    /// 
+    ///
     /// }
     /// #[actix_web::main]
     /// async fn main() -> std::io::Result<()> {
@@ -218,43 +221,62 @@ impl InteractionHandler {
     }
 
     /// Register an command with Discord!
-    pub async fn register_command_handle(&mut self, guild: impl Into<Snowflake>, cmd: ApplicationCommand, func: HandlerFunction) -> Result<ApplicationCommand, HttpError>{
+    pub async fn register_command_handle(
+        &mut self,
+        guild: impl Into<Snowflake>,
+        cmd: ApplicationCommand,
+        func: HandlerFunction,
+    ) -> Result<ApplicationCommand, HttpError> {
         let g = guild.into();
 
-        let url = format!("{}/applications/{}/guilds/{}/commands", crate::BASE_URL, self.application_id, g);
+        let url = format!(
+            "{}/applications/{}/guilds/{}/commands",
+            crate::BASE_URL,
+            self.application_id,
+            g
+        );
 
         let r = self.client.post(&url).json(&cmd).send().await;
 
         expect_successful_api_response_and_return!(r, ApplicationCommand, a, {
-            if let Some(id) = a.id{
+            if let Some(id) = a.id {
                 self.guild_handles.insert(id, func);
                 debug!("guild handle len: {}", self.guild_handles.len());
                 Ok(a)
-            }
-            else{
+            } else {
                 // Pretty bad if this code reaches...
-                Err(HttpError{
+                Err(HttpError {
                     code: 0,
                     message: "Command registration response did not have an ID.".to_string(),
                 })
             }
         })
-
     }
 
     /// Remove a guild handle
-    pub async fn deregister_command_handle(&mut self, guild: impl Into<Snowflake>, id: impl Into<Snowflake>) -> Result<(), HttpError>{
+    pub async fn deregister_command_handle(
+        &mut self,
+        guild: impl Into<Snowflake>,
+        id: impl Into<Snowflake>,
+    ) -> Result<(), HttpError> {
         let g = guild.into();
         let i = id.into();
 
-        let url = format!("{}/applications/{}/guilds/{}/commands/{}", crate::BASE_URL, self.application_id, g, i);
+        let url = format!(
+            "{}/applications/{}/guilds/{}/commands/{}",
+            crate::BASE_URL,
+            self.application_id,
+            g,
+            i
+        );
 
         let r = self.client.delete(&url).send().await;
 
-        expect_specific_api_response!(r, StatusCode::NO_CONTENT, {self.guild_handles.remove(&i); Ok(())})
-
+        expect_specific_api_response!(r, StatusCode::NO_CONTENT, {
+            self.guild_handles.remove(&i);
+            Ok(())
+        })
     }
-
 
     /// Entry point function for handling `Interactions`
     pub async fn interaction(&mut self, req: HttpRequest, body: String) -> Result<HttpResponse> {
@@ -321,7 +343,6 @@ impl InteractionHandler {
                             .content_type("application/json")
                             .json(response));
                     }
-                    
 
                     InteractionType::ApplicationCommand => {
                         debug!("{:#?}", self.guild_handles.len());
@@ -331,7 +352,7 @@ impl InteractionHandler {
                             error!("Failed to unwrap Interaction!");
                             return ERROR_RESPONSE!(500, "Failed to unwrap");
                         };
-                        if let Some(handler) = self.guild_handles.get(data.id.as_ref().unwrap()){
+                        if let Some(handler) = self.guild_handles.get(data.id.as_ref().unwrap()) {
                             // construct a Context
                             let ctx = Context::new(self.client.clone(), interaction);
 
@@ -339,8 +360,7 @@ impl InteractionHandler {
                             let response = handler(self, ctx).await;
 
                             match_handler_response!(response.r#type, response)
-                        }
-                        else if let Some(handler) = self
+                        } else if let Some(handler) = self
                             .global_handles
                             .get(data.name.as_ref().unwrap().as_str())
                         {
@@ -353,7 +373,6 @@ impl InteractionHandler {
                             let response = handler(self, ctx).await;
 
                             match_handler_response!(response.r#type, response)
-
                         } else {
                             error!(
                                 "No associated handler found for {}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,6 @@ pub use log;
 #[cfg(any(feature = "handler", feature = "extended-handler"))]
 pub use attributes::*;
 
-
 #[cfg(all(test, feature = "handler"))]
 mod tests;
 
@@ -96,7 +95,6 @@ macro_rules! expect_specific_api_response {
         }
     };
 }
-
 
 #[macro_export]
 #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,7 @@ macro_rules! expect_specific_api_response {
     };
 }
 
+
 #[macro_export]
 #[doc(hidden)]
 macro_rules! expect_successful_api_response_and_return {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -281,7 +281,7 @@ async fn normal_handle_value_test(ctx: Context) -> InteractionResponse {
 }
 #[allow(unused_must_use)]
 #[slash_command_test]
-async fn normal_handle_direct_test(_: Context) -> InteractionResponse {
+async fn normal_handle_direct_test(_ctx: Context) -> InteractionResponse {
     return InteractionResponseBuilder::default()
         .content("TEST")
         .finish();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -6,6 +6,8 @@ use crate::types::interaction::{
 };
 use crate::*;
 
+use std::sync::Mutex;
+
 use actix_web::{http, test, web, App, HttpRequest};
 use ed25519_dalek::PublicKey;
 use log::error;
@@ -78,11 +80,12 @@ Discord Interactions API tests (endpoint: /api/discord/interactions)
 
 macro_rules! interaction_app_init {
     ($ih: ident) => {
-        test::init_service(App::new().data($ih.clone()).route(
+        
+        test::init_service(App::new().app_data($ih.clone()).route(
             "/api/discord/interactions",
             web::post().to(
-                |data: web::Data<InteractionHandler>, req: HttpRequest, body: String| async move {
-                    data.interaction(req, body).await
+                |data: web::Data<Mutex<InteractionHandler>>, req: HttpRequest, body: String| async move {
+                    data.lock().unwrap().interaction(req, body).await
                 },
             ),
         ))
@@ -92,14 +95,14 @@ macro_rules! interaction_app_init {
 #[cfg(all(feature = "handler", not(feature = "extended-handler")))]
 macro_rules! init_handler {
     () => {
-        InteractionHandler::new(TEST_PUB_KEY, None)
+        InteractionHandler::new(0, TEST_PUB_KEY, None)
     };
 }
 
 #[cfg(feature = "extended-handler")]
 macro_rules! init_handler {
     () => {
-        InteractionHandler::new(TEST_PUB_KEY, Some(EMPTY_TOKEN))
+        InteractionHandler::new(0, TEST_PUB_KEY, Some(EMPTY_TOKEN))
     };
 }
 
@@ -109,7 +112,8 @@ macro_rules! init_handler {
 async fn interactions_no_content_type_header_test() {
     let ih = init_handler!();
 
-    let mut app = interaction_app_init!(ih);
+    let data = web::Data::new(Mutex::new(ih));
+    let mut app = interaction_app_init!(data);
 
     let req = test::TestRequest::post()
         .uri("/api/discord/interactions")
@@ -127,7 +131,8 @@ async fn interactions_no_content_type_header_test() {
 async fn interactions_bad_content_type_header_test() {
     let ih = init_handler!();
 
-    let mut app = interaction_app_init!(ih);
+    let data = web::Data::new(Mutex::new(ih));
+    let mut app = interaction_app_init!(data);
 
     let req = test::TestRequest::post()
         .uri("/api/discord/interactions")
@@ -146,7 +151,8 @@ async fn interactions_bad_content_type_header_test() {
 async fn interactions_no_signature_header_test() {
     let ih = init_handler!();
 
-    let mut app = interaction_app_init!(ih);
+    let data = web::Data::new(Mutex::new(ih));
+    let mut app = interaction_app_init!(data);
 
     let req = test::TestRequest::post()
         .uri("/api/discord/interactions")
@@ -166,7 +172,8 @@ async fn interactions_no_signature_header_test() {
 async fn interactions_no_timestamp_header_test() {
     let ih = init_handler!();
 
-    let mut app = interaction_app_init!(ih);
+    let data = web::Data::new(Mutex::new(ih));
+    let mut app = interaction_app_init!(data);
 
     let req = test::TestRequest::post()
         .uri("/api/discord/interactions")
@@ -186,7 +193,8 @@ async fn interactions_no_timestamp_header_test() {
 async fn interactions_bad_signature_length_short_test() {
     let ih = init_handler!();
 
-    let mut app = interaction_app_init!(ih);
+    let data = web::Data::new(Mutex::new(ih));
+    let mut app = interaction_app_init!(data);
 
     let req = test::TestRequest::post()
         .uri("/api/discord/interactions")
@@ -209,7 +217,8 @@ async fn interactions_bad_signature_length_short_test() {
 async fn interactions_bad_signature_length_too_long_test() {
     let ih = init_handler!();
 
-    let mut app = interaction_app_init!(ih);
+    let data = web::Data::new(Mutex::new(ih));
+    let mut app = interaction_app_init!(data);
 
     let req = test::TestRequest::post()
         .uri("/api/discord/interactions")
@@ -229,7 +238,8 @@ async fn interactions_bad_signature_length_too_long_test() {
 async fn interactions_ping_test() {
     let ih = init_handler!();
 
-    let mut app = interaction_app_init!(ih);
+    let data = web::Data::new(Mutex::new(ih));
+    let mut app = interaction_app_init!(data);
 
     let req = test::TestRequest::post()
         .uri("/api/discord/interactions")
@@ -254,7 +264,8 @@ async fn interactions_ping_test() {
 async fn interactions_bad_body_test() {
     let ih = init_handler!();
 
-    let mut app = interaction_app_init!(ih);
+    let data = web::Data::new(Mutex::new(ih));
+    let mut app = interaction_app_init!(data);
 
     let req = test::TestRequest::post()
         .uri("/api/discord/interactions")
@@ -293,7 +304,8 @@ async fn interactions_normal_handle_test() {
 
     ih.add_global_command("test", normal_handle_test);
 
-    let mut app = interaction_app_init!(ih);
+    let data = web::Data::new(Mutex::new(ih));
+    let mut app = interaction_app_init!(data);
 
     let req = test::TestRequest::post()
         .uri("/api/discord/interactions")
@@ -321,7 +333,8 @@ async fn interactions_normal_from_value_handle_test() {
 
     ih.add_global_command("test", normal_handle_direct_test);
 
-    let mut app = interaction_app_init!(ih);
+    let data = web::Data::new(Mutex::new(ih));
+    let mut app = interaction_app_init!(data);
 
     let req = test::TestRequest::post()
         .uri("/api/discord/interactions")
@@ -349,7 +362,8 @@ async fn interactions_normal_from_direct_call_handle_test() {
 
     ih.add_global_command("test", normal_handle_value_test);
 
-    let mut app = interaction_app_init!(ih);
+    let data = web::Data::new(Mutex::new(ih));
+    let mut app = interaction_app_init!(data);
 
     let req = test::TestRequest::post()
         .uri("/api/discord/interactions")
@@ -400,7 +414,8 @@ async fn interactions_deffered_handle_test() {
 
     ih.add_global_command("test", deffered_handle_test);
 
-    let mut app = interaction_app_init!(ih);
+    let data = web::Data::new(Mutex::new(ih));
+    let mut app = interaction_app_init!(data);
 
     let req = test::TestRequest::post()
         .uri("/api/discord/interactions")
@@ -428,8 +443,8 @@ async fn interactions_deffered_from_value_handle_test() {
     let mut ih = init_handler!();
 
     ih.add_global_command("test", deffered_handle_value_test);
-
-    let mut app = interaction_app_init!(ih);
+    let data = web::Data::new(Mutex::new(ih));
+    let mut app = interaction_app_init!(data);
 
     let req = test::TestRequest::post()
         .uri("/api/discord/interactions")
@@ -455,10 +470,10 @@ async fn interactions_deffered_from_value_handle_test() {
 #[actix_rt::test]
 async fn interactions_deffered_from_direct_value_handle_test() {
     let mut ih = init_handler!();
-
+    
     ih.add_global_command("test", deffered_handle_direct_test);
-
-    let mut app = interaction_app_init!(ih);
+    let data = web::Data::new(Mutex::new(ih));
+    let mut app = interaction_app_init!(data);
 
     let req = test::TestRequest::post()
         .uri("/api/discord/interactions")

--- a/src/types/application.rs
+++ b/src/types/application.rs
@@ -7,19 +7,34 @@ use super::Snowflake;
 use serde_repr::*;
 
 #[serde_as]
-#[derive(Clone, Serialize, Deserialize, Debug)]
-struct ApplicationCommand {
-    #[serde_as(as = "DisplayFromStr")]
-    id: Snowflake,
-    #[serde_as(as = "DisplayFromStr")]
-    application_id: Snowflake,
+#[skip_serializing_none]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+pub struct ApplicationCommand {
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(default)]
+    pub id: Option<Snowflake>,
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(default)]
+    application_id: Option<Snowflake>,
     name: String,
     description: String,
     options: Vec<ApplicationCommandOption>,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
-struct ApplicationCommandOption {
+impl Default for ApplicationCommand{
+    fn default() -> Self{
+        Self{
+            id: None,
+            application_id: None,
+            name: String::new(),
+            description: String::new(),
+            options: Vec::new(),
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+pub struct ApplicationCommandOption {
     r#type: i8,
     name: String,
     description: String,
@@ -50,8 +65,8 @@ pub enum ApplicationCommandOptionType {
     Role = 8,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
-struct ApplicationCommandOptionChoice {
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+pub struct ApplicationCommandOptionChoice {
     name: String,
     // This can be int
     value: String,
@@ -76,6 +91,7 @@ pub struct ApplicationCommandInteractionData {
     /// For components, the custom identifier for the developer
     pub custom_id: Option<String>,
 }
+
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 /// Representing a bunch of options for slash commands
 pub struct ApplicationCommandInteractionDataOption {
@@ -85,4 +101,37 @@ pub struct ApplicationCommandInteractionDataOption {
     pub value: String,
     /// More options
     pub options: Option<Vec<ApplicationCommandInteractionDataOption>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct SlashCommandDefinitionBuilder{
+    obj: ApplicationCommand
+}
+
+impl Default for SlashCommandDefinitionBuilder{
+    fn default() -> Self{
+        Self{
+            obj: ApplicationCommand::default(),
+        }
+    }
+}
+
+impl SlashCommandDefinitionBuilder{
+    pub fn name(mut self, name: impl Into<String>) -> Self{
+        let n = name.into();
+
+        self.obj.name = n;
+        self
+    }
+
+    pub fn description(mut self, desc: impl Into<String>) -> Self{
+        let d = desc.into();
+
+        self.obj.description = d;
+        self
+    }
+
+    pub fn finish(self) -> ApplicationCommand{
+        self.obj
+    }
 }

--- a/src/types/application.rs
+++ b/src/types/application.rs
@@ -9,9 +9,11 @@ use serde_repr::*;
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+/// AKA a 'slash command'.
 pub struct ApplicationCommand {
     #[serde_as(as = "Option<DisplayFromStr>")]
     #[serde(default)]
+    /// ID of command
     pub id: Option<Snowflake>,
     #[serde_as(as = "Option<DisplayFromStr>")]
     #[serde(default)]
@@ -34,6 +36,7 @@ impl Default for ApplicationCommand{
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+/// Command option
 pub struct ApplicationCommandOption {
     r#type: i8,
     name: String,
@@ -66,6 +69,7 @@ pub enum ApplicationCommandOptionType {
 }
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+/// Command option choice
 pub struct ApplicationCommandOptionChoice {
     name: String,
     // This can be int
@@ -104,6 +108,7 @@ pub struct ApplicationCommandInteractionDataOption {
 }
 
 #[derive(Clone, Debug)]
+/// Simple builder for defining SlashCommands
 pub struct SlashCommandDefinitionBuilder{
     obj: ApplicationCommand
 }
@@ -117,20 +122,21 @@ impl Default for SlashCommandDefinitionBuilder{
 }
 
 impl SlashCommandDefinitionBuilder{
+    /// Name of slash command
     pub fn name(mut self, name: impl Into<String>) -> Self{
         let n = name.into();
 
         self.obj.name = n;
         self
     }
-
+    /// Command description
     pub fn description(mut self, desc: impl Into<String>) -> Self{
         let d = desc.into();
 
         self.obj.description = d;
         self
     }
-
+    /// Finish building slash command
     pub fn finish(self) -> ApplicationCommand{
         self.obj
     }

--- a/src/types/application.rs
+++ b/src/types/application.rs
@@ -18,7 +18,7 @@ pub struct ApplicationCommand {
     application_id: Option<Snowflake>,
     name: String,
     description: String,
-    options: Vec<ApplicationCommandOption>,
+    options: Option<Vec<ApplicationCommandOption>>,
 }
 
 impl Default for ApplicationCommand{
@@ -28,7 +28,7 @@ impl Default for ApplicationCommand{
             application_id: None,
             name: String::new(),
             description: String::new(),
-            options: Vec::new(),
+            options: None,
         }
     }
 }

--- a/src/types/application.rs
+++ b/src/types/application.rs
@@ -136,6 +136,20 @@ impl SlashCommandDefinitionBuilder {
         self.obj.description = d;
         self
     }
+
+    /// Adds an option ([`ApplicationCommandOption`]) to the slash command definition
+    pub fn add_option(mut self, opt: ApplicationCommandOption) -> Self{
+        match self.obj.options.as_mut(){
+            None => {
+                self.obj.options = Some(vec![opt]);
+            }
+            Some(o) => {
+                o.push(opt);
+            }
+        }
+        self
+    }
+
     /// Finish building slash command
     pub fn finish(self) -> ApplicationCommand {
         self.obj

--- a/src/types/application.rs
+++ b/src/types/application.rs
@@ -23,9 +23,9 @@ pub struct ApplicationCommand {
     options: Option<Vec<ApplicationCommandOption>>,
 }
 
-impl Default for ApplicationCommand{
-    fn default() -> Self{
-        Self{
+impl Default for ApplicationCommand {
+    fn default() -> Self {
+        Self {
             id: None,
             application_id: None,
             name: String::new(),
@@ -109,35 +109,35 @@ pub struct ApplicationCommandInteractionDataOption {
 
 #[derive(Clone, Debug)]
 /// Simple builder for defining SlashCommands
-pub struct SlashCommandDefinitionBuilder{
-    obj: ApplicationCommand
+pub struct SlashCommandDefinitionBuilder {
+    obj: ApplicationCommand,
 }
 
-impl Default for SlashCommandDefinitionBuilder{
-    fn default() -> Self{
-        Self{
+impl Default for SlashCommandDefinitionBuilder {
+    fn default() -> Self {
+        Self {
             obj: ApplicationCommand::default(),
         }
     }
 }
 
-impl SlashCommandDefinitionBuilder{
+impl SlashCommandDefinitionBuilder {
     /// Name of slash command
-    pub fn name(mut self, name: impl Into<String>) -> Self{
+    pub fn name(mut self, name: impl Into<String>) -> Self {
         let n = name.into();
 
         self.obj.name = n;
         self
     }
     /// Command description
-    pub fn description(mut self, desc: impl Into<String>) -> Self{
+    pub fn description(mut self, desc: impl Into<String>) -> Self {
         let d = desc.into();
 
         self.obj.description = d;
         self
     }
     /// Finish building slash command
-    pub fn finish(self) -> ApplicationCommand{
+    pub fn finish(self) -> ApplicationCommand {
         self.obj
     }
 }

--- a/src/types/embed.rs
+++ b/src/types/embed.rs
@@ -155,9 +155,9 @@ impl From<u32> for Color {
     }
 }
 
-impl Into<u32> for Color {
-    fn into(self) -> u32 {
-        ((self.red as u32) << 16) | ((self.green as u32) << 8) | self.blue as u32
+impl From<Color> for u32 {
+    fn from(c: Color) -> u32 {
+        ((c.red as u32) << 16) | ((c.green as u32) << 8) | c.blue as u32
     }
 }
 

--- a/src/types/guild.rs
+++ b/src/types/guild.rs
@@ -88,9 +88,9 @@ pub struct Guild {
     pub nsfw: bool,
 }
 
-impl Into<Snowflake> for Guild {
-    fn into(self) -> Snowflake {
-        self.id
+impl From<Guild> for Snowflake {
+    fn from(g: Guild) -> Snowflake {
+        g.id
     }
 }
 

--- a/src/types/user.rs
+++ b/src/types/user.rs
@@ -43,9 +43,8 @@ pub struct User {
     pub public_flags: Option<i32>,
 }
 
-
-impl PartialEq for User{
-    fn eq(&self, other: &Self) -> bool{
+impl PartialEq for User {
+    fn eq(&self, other: &Self) -> bool {
         self.id == other.id
     }
 }
@@ -86,8 +85,8 @@ impl From<Member> for User {
     }
 }
 
-impl PartialEq for Member{
-    fn eq(&self, other: &Self) -> bool{
+impl PartialEq for Member {
+    fn eq(&self, other: &Self) -> bool {
         self.user.id == other.user.id
     }
 }


### PR DESCRIPTION
This will also allow users to access the `InteractionHandler` that called their handler function (if they wish). This way, they can manage (de)register guild commands if they need to. 