### PR TITLE
breaking change: responses require a Result.

### DIFF
--- a/attributes/src/lib.rs
+++ b/attributes/src/lib.rs
@@ -151,13 +151,18 @@ fn handler(
 
                     ::rusty_interaction::actix::Arbiter::spawn(async move {
                         
-                        let response = #act_fn (&mut __ih_c, ctx.clone()).await;
-
-                        if response.r#type != InteractionResponseType::Pong && response.r#type != InteractionResponseType::None{
-                            if let Err(i) = ctx.edit_original(&WebhookMessage::from(response)).await{
-                                ::rusty_interaction::log::error!("Editing original message failed: {:?}", i);
+                        let __response = #act_fn (&mut __ih_c, ctx.clone()).await;
+                        if let Ok(__r) = __response{
+                            if __r.r#type != InteractionResponseType::Pong && __r.r#type != InteractionResponseType::None{
+                                if let Err(i) = ctx.edit_original(&WebhookMessage::from(__r)).await{
+                                    ::rusty_interaction::log::error!("Editing original message failed: {:?}", i);
+                                }
                             }
                         }
+                        else{
+                            // Nothing
+                        }
+                        
 
                     });
 

--- a/attributes/src/lib.rs
+++ b/attributes/src/lib.rs
@@ -49,7 +49,7 @@ fn handler(
     // Check for a proper return type and fill ret if found.
     match ret_sig {
         ReturnType::Default => {
-            panic!("Expected an `InteractionResponse` return type, but got no return type. Consider adding `-> InteractionResponse` to your function signature.");
+            panic!("Expected an `Result<InteractionResponse, ()>` return type, but got no return type. Consider adding `-> Result<InteractionResponse, ()>` to your function signature.");
         }
         ReturnType::Type(_a, b) => {
             ret = *b.clone();

--- a/examples/e1_basic_handler/src/main.rs
+++ b/examples/e1_basic_handler/src/main.rs
@@ -14,7 +14,7 @@ const APP_ID: u64 = 0;
 // This macro will transform the function to something the handler can use
 #[slash_command]
 // Function handlers should take an `Interaction` object and should return an `InteractionResponse`
-async fn test(ctx: Context) -> InteractionResponse{
+async fn test(ctx: Context) -> Result<InteractionResponse, ()>{
     println!("I HAVE BEEN SUMMONED!!!");
         
     // Return a response by using the `Context.respond` function.

--- a/examples/e2_tls_handler/src/main.rs
+++ b/examples/e2_tls_handler/src/main.rs
@@ -17,7 +17,7 @@ const APP_ID: u64 = 0;
 // This macro will transform the function to something the handler can use
 #[slash_command]
 // Function handlers should take an `Interaction` object and should return an `InteractionResponse`
-async fn test(ctx: Context) -> InteractionResponse{
+async fn test(ctx: Context) -> Result<InteractionResponse, ()>{
     println!("I HAVE BEEN SUMMONED!!!");
         
     // Return a response by using the `Context.respond` function.

--- a/examples/e3_deffering_commands/src/main.rs
+++ b/examples/e3_deffering_commands/src/main.rs
@@ -13,7 +13,7 @@ const APP_ID: u64 = 0;
 #[slash_command]
 // Sending a deffered response by adding the `#[defer]` attribute
 #[defer]
-async fn test(ctx: Context) -> InteractionResponse{
+async fn test(ctx: Context) -> Result<InteractionResponse, ()>{
     println!("I HAVE BEEN SUMMONED!!!");
     
     // This is representing some work that needs to be done before a response can be made

--- a/examples/e4_followups/src/main.rs
+++ b/examples/e4_followups/src/main.rs
@@ -11,7 +11,7 @@ const PUB_KEY: &str = "YOUR_PUBLIC_KEY";
 const APP_ID: u64 = 0; 
 
 #[slash_command]
-async fn test(ctx: Context) -> InteractionResponse{
+async fn test(ctx: Context) -> Result<InteractionResponse, ()>{
     
 
     // Send a followup message

--- a/examples/e5_manipulating_original_message/src/main.rs
+++ b/examples/e5_manipulating_original_message/src/main.rs
@@ -17,7 +17,7 @@ const PUB_KEY: &str = "YOUR_PUBLIC_KEY";
 const APP_ID: u64 = 0; 
 
 #[slash_command]
-async fn test(ctx: Context) -> InteractionResponse{
+async fn test(ctx: Context) -> Result<InteractionResponse, ()>{
 
 
     let m = ctx.clone();

--- a/examples/e6_components/src/main.rs
+++ b/examples/e6_components/src/main.rs
@@ -17,21 +17,21 @@ const APP_ID: u64 = 0;
 
 // Use the component_handler macro.
 #[component_handler]
-async fn edit_button(ctx: Context) -> InteractionResponse{
+async fn edit_button(ctx: Context) -> Result<InteractionResponse, ()>{
     return ctx.respond().message("HAHA").finish();
 }
 
 // We defer in this instance, because we don't want to edit anything
 #[component_handler]
 #[defer]
-async fn delete_button(ctx: Context) -> InteractionResponse{
+async fn delete_button(ctx: Context) -> Result<InteractionResponse, ()>{
     ctx.delete_original().await;
 
     // Since we've deleted the original message, it's safe to use respond().none()
     return ctx.respond().none();
 }
 #[slash_command]
-async fn test(ctx: Context) -> InteractionResponse{
+async fn test(ctx: Context) -> Result<InteractionResponse, ()>{
 
     // Let's build our message!
     let resp = ctx.respond()

--- a/examples/e7_embeds/src/main.rs
+++ b/examples/e7_embeds/src/main.rs
@@ -13,21 +13,21 @@ const APP_ID: u64 = 0;
 
 // Use the component_handler macro.
 #[component_handler]
-async fn edit_button(ctx: Context) -> InteractionResponse{
+async fn edit_button(ctx: Context) -> Result<InteractionResponse, ()>{
     return ctx.respond().message("HAHA").finish();
 }
 
 // We defer in this instance, because we don't want to edit anything
 #[component_handler]
 #[defer]
-async fn delete_button(ctx: Context) -> InteractionResponse{
+async fn delete_button(ctx: Context) -> Result<InteractionResponse, ()>{
     if let Ok(_) = ctx.delete_original().await{
 
     }
     return ctx.respond().none();
 }
 #[slash_command]
-async fn test(ctx: Context) -> InteractionResponse{
+async fn test(ctx: Context) -> Result<InteractionResponse, ()>{
 
     // You can use the EmbedBuilder to build embeds
     // ...you might have figured that out when looking at the name.

--- a/examples/e8_managing_commands/src/main.rs
+++ b/examples/e8_managing_commands/src/main.rs
@@ -11,14 +11,14 @@ const TOKEN: &str = "MY TOKEN";
 const APP_ID: u64 = 00000000000000000;
 
 #[slash_command]
-async fn delete_self(handler: &mut InteractionHandler, ctx: Context) -> InteractionResponse{
+async fn delete_self(handler: &mut InteractionHandler, ctx: Context) -> Result<InteractionResponse, ()>{
     let sec_ctx = ctx.clone();
     if let Some(g) = sec_ctx.interaction.guild_id{
         if let Some(data) = sec_ctx.interaction.data{
             let cid = data.id;
 
             // Using this to remove the guild command
-            let r = handler.deregister_guild_handle(g, cid.unwrap(), &ManipulationScope::All).await;
+            let r = handler.deregister_guild_handle(g, cid, &ManipulationScope::All).await;
             if r.is_ok(){
                 return ctx.respond().content("`/generated` deleted!").finish();
             }
@@ -34,7 +34,7 @@ async fn delete_self(handler: &mut InteractionHandler, ctx: Context) -> Interact
 }
 
 #[slash_command]
-async fn test(handler: &mut InteractionHandler, ctx: Context) -> InteractionResponse{
+async fn test(handler: &mut InteractionHandler, ctx: Context) -> Result<InteractionResponse, ()>{
 
     if let Some(i) = ctx.interaction.guild_id{
         

--- a/examples/e9_accessing_other_data/src/main.rs
+++ b/examples/e9_accessing_other_data/src/main.rs
@@ -16,7 +16,7 @@ struct MyStruct{
 }
 
 #[slash_command]
-async fn test(handler: &mut InteractionHandler, ctx: Context) -> InteractionResponse{
+async fn test(handler: &mut InteractionHandler, ctx: Context) -> Result<InteractionResponse, ()>{
 
     // Get a mutable reference to MyStruct
     let my_struct = handler.data.get_mut::<MyStruct>().unwrap();

--- a/src/types/interaction.rs
+++ b/src/types/interaction.rs
@@ -151,14 +151,14 @@ impl InteractionResponseBuilder {
     }
 
     /// Return a pong with no data. Use with caution
-    pub fn pong(mut self) -> InteractionResponse {
+    pub fn pong(mut self) -> Result<InteractionResponse, ()> {
         self.r#type = InteractionResponseType::Pong;
         self.data = None;
         self.finish()
     }
 
     /// Return without any data. Use with caution
-    pub fn none(mut self) -> InteractionResponse {
+    pub fn none(mut self) -> Result<InteractionResponse, ()> {
         self.r#type = InteractionResponseType::None;
         self.data = None;
         self.finish()
@@ -261,8 +261,11 @@ impl InteractionResponseBuilder {
 
     /// Returns an `InteractionResponse`, consuming itself.
     /// You can't use the builder anymore after you called this function.
-    pub fn finish(self) -> InteractionResponse {
-        self.ret()
+    /// 
+    /// # Note
+    /// This function retuns an `Ok`, no matter what.
+    pub fn finish(self) -> Result<InteractionResponse, ()> {
+        Ok(self.ret())
     }
 }
 


### PR DESCRIPTION
`InteractionResponse` -> `Result<InteractionResponse>`.

This is to allow end-users and Discord that the Interaction has failed. 