### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ reqwest = { version = "0.10.10", features = ["json"], optional = true }
 
 async-trait = { version = "0.1", optional = true }
 
-log = { version = "0", optional = true }
+log = { version = "0.4", optional = true }
 
 anymap = {version = "0.12", optional = true}
 [dependencies.serde]


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.